### PR TITLE
feat: Update console autocomplete to search from any part of the word

### DIFF
--- a/js/console.js
+++ b/js/console.js
@@ -1239,17 +1239,17 @@ function updateSuggestions(inputValue) {
 
     if (parts.length === 1) {
         // Command suggestions
-        suggestions = Object.keys(commandHelpInfo).filter(cmd => cmd.startsWith(command));
+        suggestions = Object.keys(commandHelpInfo).filter(cmd => cmd.includes(command));
     } else {
         // Argument suggestions
         switch (command) {
             case 'additem':
             case 'removeitem':
             case 'placeitem':
-                suggestions = Object.keys(window.assetManager.itemsById).filter(id => id.toLowerCase().startsWith(currentArg.toLowerCase()));
+                suggestions = Object.keys(window.assetManager.itemsById).filter(id => id.toLowerCase().includes(currentArg.toLowerCase()));
                 break;
             case 'spawnnpc':
-                suggestions = Object.keys(window.assetManager.npcsById).filter(id => id.toLowerCase().startsWith(currentArg.toLowerCase()));
+                suggestions = Object.keys(window.assetManager.npcsById).filter(id => id.toLowerCase().includes(currentArg.toLowerCase()));
                 break;
             // Add more cases for other commands that need argument suggestions
             default:


### PR DESCRIPTION
This change updates the console autocompletion to search from any part of the word, instead of just the beginning. This provides a more flexible and user-friendly search experience.

The filtering logic in `js/console.js` has been changed from `startsWith` to `includes` for both command and argument suggestions.