### PR TITLE
Fix farming and food consumption loop

### DIFF
--- a/assets/definitions/items/consumables.json
+++ b/assets/definitions/items/consumables.json
@@ -307,7 +307,7 @@
       "modern"
     ],
     "effects": {
-      "hunger": -12
+      "hunger": 12
     },
     "family": "food",
     "properties": {
@@ -332,7 +332,7 @@
       "modern"
     ],
     "effects": {
-      "hunger": -8,
+      "hunger": 8,
       "stamina": 20
     },
     "family": "food",
@@ -359,7 +359,7 @@
       "military"
     ],
     "effects": {
-      "hunger": -24,
+      "hunger": 24,
       "thirst": -10
     },
     "family": "food",
@@ -779,7 +779,7 @@
       "survivor"
     ],
     "effects": {
-      "hunger": -24,
+      "hunger": 24,
       "thirst": -20
     },
     "family": "food",
@@ -1137,12 +1137,83 @@
     "type": "consumable_medical",
     "size": 0,
     "weightLbs": 0.5,
-    "tags": ["consumable", "medical", "radiation", "radaway"],
+    "tags": [
+      "consumable",
+      "medical",
+      "radiation",
+      "radaway"
+    ],
     "effects": {
       "radiation_reduction": 100
     },
     "doses": 1,
     "sprite": "!",
     "color": "#ffa500"
+  },
+  {
+    "id": "corn_cob",
+    "name": "Corn Cob",
+    "description": "A freshly harvested ear of corn.",
+    "size": 1,
+    "type": "food",
+    "isConsumable": true,
+    "effects": {
+      "hunger": 6
+    },
+    "sprite": "o",
+    "color": "#ffff00",
+    "canEquip": false,
+    "isClothing": false,
+    "weightLbs": 0.5,
+    "tags": [
+      "consumable",
+      "food",
+      "raw"
+    ],
+    "family": "food"
+  },
+  {
+    "id": "carrot",
+    "name": "Carrot",
+    "description": "A crunchy, orange root vegetable.",
+    "size": 1,
+    "type": "food",
+    "isConsumable": true,
+    "effects": {
+      "hunger": 4
+    },
+    "sprite": "v",
+    "color": "#ffa500",
+    "canEquip": false,
+    "isClothing": false,
+    "weightLbs": 0.2,
+    "tags": [
+      "consumable",
+      "food",
+      "raw"
+    ],
+    "family": "food"
+  },
+  {
+    "id": "tomato",
+    "name": "Tomato",
+    "description": "A juicy, red tomato.",
+    "size": 1,
+    "type": "food",
+    "isConsumable": true,
+    "effects": {
+      "hunger": 5
+    },
+    "sprite": "o",
+    "color": "#ff0000",
+    "canEquip": false,
+    "isClothing": false,
+    "weightLbs": 0.3,
+    "tags": [
+      "consumable",
+      "food",
+      "raw"
+    ],
+    "family": "food"
   }
 ]

--- a/assets/definitions/loot_tables.json
+++ b/assets/definitions/loot_tables.json
@@ -1,161 +1,740 @@
 {
   "harvest:wood": [
-    { "itemId": "wood_log", "chance": 0.4, "min": 1, "max": 2 },
-    { "itemId": "wood_stick", "chance": 0.5, "min": 1, "max": 4 },
-    { "itemId": "plant_fibers_strong", "chance": 0.2, "min": 1, "max": 3 },
-    { "itemId": "tree_bark_brown_pigment", "chance": 0.1, "min": 1, "max": 2 },
-    { "itemId": "feather", "chance": 0.15, "min": 1, "max": 3 }
+    {
+      "itemId": "wood_log",
+      "chance": 0.4,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "wood_stick",
+      "chance": 0.5,
+      "min": 1,
+      "max": 4
+    },
+    {
+      "itemId": "plant_fibers_strong",
+      "chance": 0.2,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "tree_bark_brown_pigment",
+      "chance": 0.1,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "feather",
+      "chance": 0.15,
+      "min": 1,
+      "max": 3
+    }
   ],
   "harvest:stone": [
-    { "itemId": "stone_chunk", "chance": 0.6, "min": 1, "max": 3 },
-    { "itemId": "stone_sharp_fragment", "chance": 0.3, "min": 1, "max": 2 },
-    { "itemId": "iron_ore", "chance": 0.1, "min": 1, "max": 2 },
-    { "itemId": "copper_ore", "chance": 0.1, "min": 1, "max": 2 },
-    { "itemId": "chemical_reagent_sulfur", "chance": 0.05, "min": 1, "max": 2 },
-    { "itemId": "chemical_reagent_saltpeter", "chance": 0.05, "min": 1, "max": 2 },
-    { "itemId": "rock_large_suitable", "chance": 0.02, "min": 1, "max": 1 },
-    { "itemId": "gemstone_uncut_small", "chance": 0.01, "min": 1, "max": 1 },
-    { "itemId": "gold_dust_pouch", "chance": 0.005, "min": 1, "max": 1 },
-    { "itemId": "silver_nugget", "chance": 0.01, "min": 1, "max": 1 }
+    {
+      "itemId": "stone_chunk",
+      "chance": 0.6,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "stone_sharp_fragment",
+      "chance": 0.3,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "iron_ore",
+      "chance": 0.1,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "copper_ore",
+      "chance": 0.1,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "chemical_reagent_sulfur",
+      "chance": 0.05,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "chemical_reagent_saltpeter",
+      "chance": 0.05,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "rock_large_suitable",
+      "chance": 0.02,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "gemstone_uncut_small",
+      "chance": 0.01,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "gold_dust_pouch",
+      "chance": 0.005,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "silver_nugget",
+      "chance": 0.01,
+      "min": 1,
+      "max": 1
+    }
   ],
   "harvest:plant": [
-    { "itemId": "plant_fibers_strong", "chance": 0.6, "min": 1, "max": 4 },
-    { "itemId": "plant_leaves_green_pigment", "chance": 0.3, "min": 1, "max": 2 },
-    { "itemId": "medicinal_herb_comfrey", "chance": 0.1, "min": 1, "max": 1 },
-    { "itemId": "tomato_seeds", "chance": 0.05, "min": 1, "max": 1 },
-    { "itemId": "carrot_seeds", "chance": 0.05, "min": 1, "max": 1 },
-    { "itemId": "beeswax_chunk", "chance": 0.05, "min": 1, "max": 1 }
+    {
+      "itemId": "plant_fibers_strong",
+      "chance": 0.6,
+      "min": 1,
+      "max": 4
+    },
+    {
+      "itemId": "plant_leaves_green_pigment",
+      "chance": 0.3,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "medicinal_herb_comfrey",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "tomato_seeds",
+      "chance": 0.05,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "carrot_seeds",
+      "chance": 0.05,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "beeswax_chunk",
+      "chance": 0.05,
+      "min": 1,
+      "max": 1
+    }
   ],
   "harvest:sand": [
-    { "itemId": "sand_pile", "chance": 0.8, "min": 1, "max": 3 },
-    { "itemId": "clay_lump", "chance": 0.1, "min": 1, "max": 1 },
-    { "itemId": "stone_sharp_fragment", "chance": 0.1, "min": 1, "max": 1 }
+    {
+      "itemId": "sand_pile",
+      "chance": 0.8,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "clay_lump",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "stone_sharp_fragment",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    }
   ],
   "scavenge:furniture": [
-    { "itemId": "nails", "chance": 0.4, "min": 1, "max": 5 },
-    { "itemId": "wood_planks", "chance": 0.2, "min": 1, "max": 1 },
-    { "itemId": "cloth_scrap", "chance": 0.3, "min": 1, "max": 3 },
-    { "itemId": "spring_small_metal", "chance": 0.1, "min": 1, "max": 2 }
+    {
+      "itemId": "nails",
+      "chance": 0.4,
+      "min": 1,
+      "max": 5
+    },
+    {
+      "itemId": "wood_planks",
+      "chance": 0.2,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "cloth_scrap",
+      "chance": 0.3,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "spring_small_metal",
+      "chance": 0.1,
+      "min": 1,
+      "max": 2
+    }
   ],
   "scavenge:machinery": [
-    { "itemId": "scrap_metal", "chance": 0.4, "min": 1, "max": 3 },
-    { "itemId": "gears_assorted", "chance": 0.2, "min": 1, "max": 2 },
-    { "itemId": "mechanical_parts_simple", "chance": 0.1, "min": 1, "max": 1 },
-    { "itemId": "metal_bits_small", "chance": 0.3, "min": 2, "max": 10 },
-    { "itemId": "lead_scrap", "chance": 0.1, "min": 1, "max": 2 },
-    { "itemId": "scrap_brass", "chance": 0.1, "min": 1, "max": 2 }
+    {
+      "itemId": "scrap_metal",
+      "chance": 0.4,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "gears_assorted",
+      "chance": 0.2,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "mechanical_parts_simple",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "metal_bits_small",
+      "chance": 0.3,
+      "min": 2,
+      "max": 10
+    },
+    {
+      "itemId": "lead_scrap",
+      "chance": 0.1,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "scrap_brass",
+      "chance": 0.1,
+      "min": 1,
+      "max": 2
+    }
   ],
   "harvest:mud": [
-    { "itemId": "clay_lump", "chance": 0.5, "min": 1, "max": 2 },
-    { "itemId": "stone_sharp_fragment", "chance": 0.2, "min": 1, "max": 1 }
+    {
+      "itemId": "clay_lump",
+      "chance": 0.5,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "stone_sharp_fragment",
+      "chance": 0.2,
+      "min": 1,
+      "max": 1
+    }
   ],
   "harvest:gravel": [
-    { "itemId": "stone_sharp_fragment", "chance": 0.6, "min": 1, "max": 3 },
-    { "itemId": "sand_pile", "chance": 0.3, "min": 1, "max": 2 }
+    {
+      "itemId": "stone_sharp_fragment",
+      "chance": 0.6,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "sand_pile",
+      "chance": 0.3,
+      "min": 1,
+      "max": 2
+    }
   ],
   "scavenge:electronics": [
-    { "itemId": "electronic_scrap", "chance": 0.5, "min": 1, "max": 3 },
-    { "itemId": "wire_insulated_thin", "chance": 0.4, "min": 1, "max": 3 },
-    { "itemId": "circuit_board_blank", "chance": 0.2, "min": 1, "max": 1 },
-    { "itemId": "led_basic", "chance": 0.3, "min": 1, "max": 2 },
-    { "itemId": "battery_cell_small", "chance": 0.2, "min": 1, "max": 1 },
-    { "itemId": "memory_chip_basic", "chance": 0.1, "min": 1, "max": 1 }
+    {
+      "itemId": "electronic_scrap",
+      "chance": 0.5,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "wire_insulated_thin",
+      "chance": 0.4,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "circuit_board_blank",
+      "chance": 0.2,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "led_basic",
+      "chance": 0.3,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "battery_cell_small",
+      "chance": 0.2,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "memory_chip_basic",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    }
   ],
   "scavenge:appliance": [
-    { "itemId": "scrap_metal", "chance": 0.5, "min": 1, "max": 4 },
-    { "itemId": "motor_small_electric", "chance": 0.2, "min": 1, "max": 1 },
-    { "itemId": "heating_element_nichrome_wire", "chance": 0.2, "min": 1, "max": 1 },
-    { "itemId": "rubber_hose_section", "chance": 0.2, "min": 1, "max": 1 },
-    { "itemId": "wire_insulated_thin", "chance": 0.3, "min": 1, "max": 3 }
+    {
+      "itemId": "scrap_metal",
+      "chance": 0.5,
+      "min": 1,
+      "max": 4
+    },
+    {
+      "itemId": "motor_small_electric",
+      "chance": 0.2,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "heating_element_nichrome_wire",
+      "chance": 0.2,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "rubber_hose_section",
+      "chance": 0.2,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "wire_insulated_thin",
+      "chance": 0.3,
+      "min": 1,
+      "max": 3
+    }
   ],
   "scavenge:glass": [
-    { "itemId": "sharp_glass", "chance": 0.8, "min": 1, "max": 3 }
+    {
+      "itemId": "sharp_glass",
+      "chance": 0.8,
+      "min": 1,
+      "max": 3
+    }
   ],
   "scavenge:generic": [
-    { "itemId": "scrap_metal", "chance": 0.3, "min": 1, "max": 3 },
-    { "itemId": "plastic_junk_item", "chance": 0.3, "min": 1, "max": 3 },
-    { "itemId": "cloth_scrap", "chance": 0.2, "min": 1, "max": 4 },
-    { "itemId": "glass_bottle_empty", "chance": 0.1, "min": 1, "max": 1 },
-    { "itemId": "nails", "chance": 0.15, "min": 2, "max": 10 },
-    { "itemId": "duct_tape", "chance": 0.05, "min": 1, "max": 1 }
+    {
+      "itemId": "scrap_metal",
+      "chance": 0.3,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "plastic_junk_item",
+      "chance": 0.3,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "cloth_scrap",
+      "chance": 0.2,
+      "min": 1,
+      "max": 4
+    },
+    {
+      "itemId": "glass_bottle_empty",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "nails",
+      "chance": 0.15,
+      "min": 2,
+      "max": 10
+    },
+    {
+      "itemId": "duct_tape",
+      "chance": 0.05,
+      "min": 1,
+      "max": 1
+    }
   ],
   "scavenge:junk": [
-      { "itemId": "scrap_metal", "chance": 0.5, "min": 1, "max": 5 },
-      { "itemId": "plastic_junk_item", "chance": 0.4, "min": 1, "max": 4 },
-      { "itemId": "wire_insulated_thin", "chance": 0.2, "min": 1, "max": 3 },
-      { "itemId": "electronic_scrap", "chance": 0.1, "min": 1, "max": 2 },
-      { "itemId": "old_tire", "chance": 0.05, "min": 1, "max": 1 },
-      { "itemId": "lead_scrap", "chance": 0.1, "min": 1, "max": 3 },
-      { "itemId": "scrap_brass", "chance": 0.1, "min": 1, "max": 3 },
-      { "itemId": "copper_scrap", "chance": 0.1, "min": 1, "max": 3 },
-      { "itemId": "gasoline_canister_partial", "chance": 0.05, "min": 1, "max": 1 },
-      { "itemId": "shotshell_hull_12ga", "chance": 0.2, "min": 1, "max": 5 },
-      { "itemId": "casing_grenade_40mm_metal", "chance": 0.05, "min": 1, "max": 2 }
+    {
+      "itemId": "scrap_metal",
+      "chance": 0.5,
+      "min": 1,
+      "max": 5
+    },
+    {
+      "itemId": "plastic_junk_item",
+      "chance": 0.4,
+      "min": 1,
+      "max": 4
+    },
+    {
+      "itemId": "wire_insulated_thin",
+      "chance": 0.2,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "electronic_scrap",
+      "chance": 0.1,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "old_tire",
+      "chance": 0.05,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "lead_scrap",
+      "chance": 0.1,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "scrap_brass",
+      "chance": 0.1,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "copper_scrap",
+      "chance": 0.1,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "gasoline_canister_partial",
+      "chance": 0.05,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "shotshell_hull_12ga",
+      "chance": 0.2,
+      "min": 1,
+      "max": 5
+    },
+    {
+      "itemId": "casing_grenade_40mm_metal",
+      "chance": 0.05,
+      "min": 1,
+      "max": 2
+    }
   ],
   "butcher:corpse": [
-      { "itemId": "raw_meat", "chance": 1.0, "min": 1, "max": 3 },
-      { "itemId": "bone", "chance": 0.5, "min": 1, "max": 2 },
-      { "itemId": "animal_hide_raw_small", "chance": 0.3, "min": 1, "max": 1 },
-      { "itemId": "sinew_animal", "chance": 0.2, "min": 1, "max": 2 }
+    {
+      "itemId": "raw_meat",
+      "chance": 1,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "bone",
+      "chance": 0.5,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "animal_hide_raw_small",
+      "chance": 0.3,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "sinew_animal",
+      "chance": 0.2,
+      "min": 1,
+      "max": 2
+    }
   ],
   "container:generic": [
-    { "itemId": "scrap_metal", "chance": 0.3, "min": 1, "max": 2 },
-    { "itemId": "cloth_scrap", "chance": 0.3, "min": 1, "max": 3 },
-    { "itemId": "plastic_junk_item", "chance": 0.2, "min": 1, "max": 2 },
-    { "itemId": "glass_bottle_empty", "chance": 0.1, "min": 1, "max": 1 }
+    {
+      "itemId": "scrap_metal",
+      "chance": 0.3,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "cloth_scrap",
+      "chance": 0.3,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "plastic_junk_item",
+      "chance": 0.2,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "glass_bottle_empty",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    }
   ],
   "container:cabinet": [
-    { "itemId": "canned_beans_food", "chance": 0.3, "min": 1, "max": 2 },
-    { "itemId": "bottled_water_drink", "chance": 0.3, "min": 1, "max": 2 },
-    { "itemId": "cloth_scrap", "chance": 0.2, "min": 1, "max": 3 },
-    { "itemId": "matches_box", "chance": 0.1, "min": 1, "max": 1 },
-    { "itemId": "painkillers_weak", "chance": 0.05, "min": 1, "max": 1 }
+    {
+      "itemId": "canned_beans_food",
+      "chance": 0.3,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "bottled_water_drink",
+      "chance": 0.3,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "cloth_scrap",
+      "chance": 0.2,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "matches_box",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "painkillers_weak",
+      "chance": 0.05,
+      "min": 1,
+      "max": 1
+    }
   ],
   "container:fridge": [
-    { "itemId": "bottled_water_drink", "chance": 0.5, "min": 1, "max": 3 },
-    { "itemId": "canned_meat_food", "chance": 0.3, "min": 1, "max": 2 },
-    { "itemId": "soda_can_cola", "chance": 0.2, "min": 1, "max": 2 }
+    {
+      "itemId": "bottled_water_drink",
+      "chance": 0.5,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "canned_meat_food",
+      "chance": 0.3,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "soda_can_cola",
+      "chance": 0.2,
+      "min": 1,
+      "max": 2
+    }
   ],
   "container:medical": [
-    { "itemId": "bandage_cloth", "chance": 0.5, "min": 1, "max": 3 },
-    { "itemId": "antiseptic_bottle", "chance": 0.3, "min": 1, "max": 1 },
-    { "itemId": "antibiotics_pills", "chance": 0.2, "min": 1, "max": 1 },
-    { "itemId": "first_aid_kit_basic", "chance": 0.05, "min": 1, "max": 1 }
+    {
+      "itemId": "bandage_cloth",
+      "chance": 0.5,
+      "min": 1,
+      "max": 3
+    },
+    {
+      "itemId": "antiseptic_bottle",
+      "chance": 0.3,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "antibiotics_pills",
+      "chance": 0.2,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "first_aid_kit_basic",
+      "chance": 0.05,
+      "min": 1,
+      "max": 1
+    }
   ],
   "container:desk": [
-    { "itemId": "parchment_roll_blank", "chance": 0.5, "min": 1, "max": 2 },
-    { "itemId": "pen_black", "chance": 0.3, "min": 1, "max": 1 },
-    { "itemId": "battery_cell_small", "chance": 0.2, "min": 1, "max": 2 },
-    { "itemId": "flashlight_small", "chance": 0.1, "min": 1, "max": 1 }
+    {
+      "itemId": "parchment_roll_blank",
+      "chance": 0.5,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "pen_black",
+      "chance": 0.3,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "battery_cell_small",
+      "chance": 0.2,
+      "min": 1,
+      "max": 2
+    },
+    {
+      "itemId": "flashlight_small",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    }
   ],
   "container:locker": [
-    { "itemId": "jacket_denim", "chance": 0.1, "min": 1, "max": 1 },
-    { "itemId": "boots_work", "chance": 0.1, "min": 1, "max": 1 },
-    { "itemId": "baseball_bat", "chance": 0.05, "min": 1, "max": 1 },
-    { "itemId": "crowbar_tool", "chance": 0.05, "min": 1, "max": 1 }
+    {
+      "itemId": "jacket_denim",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "boots_work",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "baseball_bat",
+      "chance": 0.05,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "crowbar_tool",
+      "chance": 0.05,
+      "min": 1,
+      "max": 1
+    }
   ],
   "container:gun_safe": [
-    { "itemId": "glock_17_9mm_autoloader", "chance": 0.1, "min": 1, "max": 1 },
-    { "itemId": "colt_m1911_45_autoloader", "chance": 0.1, "min": 1, "max": 1 },
-    { "itemId": "remington_700_7_62mm_hunting_rifle", "chance": 0.1, "min": 1, "max": 1 },
-    { "itemId": "mossberg_12_gauge_shotgun", "chance": 0.1, "min": 1, "max": 1 },
-    { "itemId": "ammo_9mm", "chance": 0.3, "min": 1, "max": 1 },
-    { "itemId": "ammo_12gauge_buckshot", "chance": 0.3, "min": 1, "max": 1 },
-    { "itemId": "ammo_762mm", "chance": 0.3, "min": 1, "max": 1 },
-    { "itemId": "primer_pistol_small", "chance": 0.3, "min": 10, "max": 50 },
-    { "itemId": "primer_pistol_large", "chance": 0.3, "min": 10, "max": 50 },
-    { "itemId": "primer_rifle_small", "chance": 0.3, "min": 10, "max": 50 },
-    { "itemId": "primer_rifle_large", "chance": 0.3, "min": 10, "max": 50 },
-    { "itemId": "primer_shotgun", "chance": 0.3, "min": 10, "max": 50 },
-    { "itemId": "wad_shotgun", "chance": 0.3, "min": 10, "max": 50 },
-    { "itemId": "shotshell_hull_10ga", "chance": 0.1, "min": 1, "max": 5 }
-],
+    {
+      "itemId": "glock_17_9mm_autoloader",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "colt_m1911_45_autoloader",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "remington_700_7_62mm_hunting_rifle",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "mossberg_12_gauge_shotgun",
+      "chance": 0.1,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "ammo_9mm",
+      "chance": 0.3,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "ammo_12gauge_buckshot",
+      "chance": 0.3,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "ammo_762mm",
+      "chance": 0.3,
+      "min": 1,
+      "max": 1
+    },
+    {
+      "itemId": "primer_pistol_small",
+      "chance": 0.3,
+      "min": 10,
+      "max": 50
+    },
+    {
+      "itemId": "primer_pistol_large",
+      "chance": 0.3,
+      "min": 10,
+      "max": 50
+    },
+    {
+      "itemId": "primer_rifle_small",
+      "chance": 0.3,
+      "min": 10,
+      "max": 50
+    },
+    {
+      "itemId": "primer_rifle_large",
+      "chance": 0.3,
+      "min": 10,
+      "max": 50
+    },
+    {
+      "itemId": "primer_shotgun",
+      "chance": 0.3,
+      "min": 10,
+      "max": 50
+    },
+    {
+      "itemId": "wad_shotgun",
+      "chance": 0.3,
+      "min": 10,
+      "max": 50
+    },
+    {
+      "itemId": "shotshell_hull_10ga",
+      "chance": 0.1,
+      "min": 1,
+      "max": 5
+    }
+  ],
   "harvest:corn": [
-    { "itemId": "corn_cob", "min": 1, "max": 3, "chance": 1.0 },
-    { "itemId": "seeds_corn", "min": 1, "max": 2, "chance": 0.5 }
+    {
+      "itemId": "corn_cob",
+      "min": 1,
+      "max": 3,
+      "chance": 1
+    },
+    {
+      "itemId": "corn_seeds",
+      "min": 1,
+      "max": 2,
+      "chance": 0.5
+    }
   ],
   "harvest:carrot": [
-    { "itemId": "carrot", "min": 1, "max": 3, "chance": 1.0 },
-    { "itemId": "seeds_carrot", "min": 1, "max": 2, "chance": 0.5 }
+    {
+      "itemId": "carrot",
+      "min": 1,
+      "max": 3,
+      "chance": 1
+    },
+    {
+      "itemId": "carrot_seeds",
+      "min": 1,
+      "max": 2,
+      "chance": 0.5
+    }
+  ],
+  "harvest:tomato": [
+    {
+      "itemId": "tomato",
+      "min": 1,
+      "max": 3,
+      "chance": 1
+    },
+    {
+      "itemId": "tomato_seeds",
+      "min": 1,
+      "max": 2,
+      "chance": 0.5
+    }
   ]
 }

--- a/assets/definitions/tileset.json
+++ b/assets/definitions/tileset.json
@@ -2660,5 +2660,42 @@
       "vegetation",
       "harvest:carrot"
     ]
+  },
+  "PL_T1": {
+    "sprite": "i",
+    "name": "Tomato (Seedling)",
+    "color": "#90EE90",
+    "tags": [
+      "plant",
+      "middle",
+      "tomato",
+      "stage1",
+      "vegetation"
+    ]
+  },
+  "PL_T2": {
+    "sprite": "l",
+    "name": "Tomato (Growing)",
+    "color": "#32CD32",
+    "tags": [
+      "plant",
+      "middle",
+      "tomato",
+      "stage2",
+      "vegetation"
+    ]
+  },
+  "PL_T3": {
+    "sprite": "Y",
+    "name": "Tomato (Ripe)",
+    "color": "#FF6347",
+    "tags": [
+      "plant",
+      "middle",
+      "tomato",
+      "stage3",
+      "vegetation",
+      "harvest:tomato"
+    ]
   }
 }

--- a/js/farmingManager.js
+++ b/js/farmingManager.js
@@ -64,19 +64,33 @@ class FarmingManager {
         }
 
         // Determine crop type from seed
-        const cropTileId = seedItem.cropTileId; // Defined in consumables.json
+        const cropTileId = seedItem.cropTileId || (seedItem.effects && seedItem.effects.growsInto); // Check both formats
         if (!cropTileId) {
             window.logToConsole("These seeds don't seem to grow into anything known.", "red");
             return;
         }
 
+        let stage1TileId = cropTileId;
+        // Check variety map or default logic
+        const varietyName = seedItem.name.replace(" Seeds", "").trim();
+        let prefix = "";
+        if (varietyName.includes("Corn")) prefix = "PL_C";
+        else if (varietyName.includes("Carrot")) prefix = "PL_R";
+        else if (varietyName.includes("Tomato")) prefix = "PL_T";
+
+        if (prefix && window.assetManager && window.assetManager.tilesets[prefix + "1"]) {
+             stage1TileId = prefix + "1";
+        } else if (prefix && !window.assetManager) {
+             stage1TileId = prefix + "1"; // Fallback if assetManager not fully loaded
+        }
+
         // Place Plant Tile
-        window.mapRenderer.updateTileOnLayer(x, y, z, 'middle', cropTileId);
+        window.mapRenderer.updateTileOnLayer(x, y, z, 'middle', stage1TileId);
 
         // Track Plot
         this.plots.push({
             x: x, y: y, z: z, mapId: mapId,
-            plantId: cropTileId,
+            plantId: stage1TileId,
             growthStage: 1,
             growthProgress: 0,
             isWatered: false,
@@ -157,6 +171,7 @@ class FarmingManager {
                 let prefix = "";
                 if (variety.includes("Corn")) prefix = "PL_C";
                 else if (variety.includes("Carrot")) prefix = "PL_R";
+                else if (variety.includes("Tomato")) prefix = "PL_T";
 
                 if (prefix) {
                     if (plot.growthStage === 1 && plot.growthProgress >= 50) {
@@ -208,9 +223,22 @@ class FarmingManager {
         const r = 4;
         const mapData = window.mapRenderer.getCurrentMapData();
 
-        // If map not loaded, assume no irrigation update? Or keep old state?
-        // If player is far away, we can't check static tiles easily without loading map data.
-        if (!mapData || mapData.id !== plot.mapId) return false;
+        // If map not loaded, we can't check easily. Fallback:
+        // Try to load the map or read from its data if it's cached in memory.
+        let targetMap = null;
+        if (mapData && mapData.id === plot.mapId) {
+            targetMap = mapData;
+        } else if (window.mapRenderer.loadedMaps && window.mapRenderer.loadedMaps[plot.mapId]) {
+            targetMap = window.mapRenderer.loadedMaps[plot.mapId];
+        } else if (window.worldData && window.worldData.maps) {
+            targetMap = window.worldData.maps.find(m => m.id === plot.mapId);
+        }
+
+        if (!targetMap) {
+            // If the map isn't loaded and we don't have its data, use a fallback:
+            // return plot.wasIrrigated (we need to track this).
+            return plot.wasIrrigated || false;
+        }
 
         // Check WaterManager first
         // Simple bounding box loop
@@ -227,18 +255,25 @@ class FarmingManager {
                 // (Max bounds check requires width/height)
 
                 // 1. Dynamic Water
-                if (window.waterManager.getWaterAt(nx, ny, plot.z)) return true;
+                if (window.waterManager.getWaterAt(nx, ny, plot.z)) {
+                    plot.wasIrrigated = true;
+                    return true;
+                }
 
                 // 2. Static Water Tile
-                const level = mapData.levels[plot.z];
+                const level = targetMap.levels[plot.z];
                 if (level && level.bottom && level.bottom[ny] && level.bottom[ny][nx]) {
                     const tile = level.bottom[ny][nx];
                     const tId = (typeof tile === 'object' && tile !== null) ? tile.tileId : tile;
-                    if (tId === "WS" || tId === "WD" || tId === "RB") return true; // Shallow, Deep, Riverbed(maybe wet?)
+                    if (tId === "WS" || tId === "WD" || tId === "RB") {
+                        plot.wasIrrigated = true;
+                        return true; // Shallow, Deep, Riverbed(maybe wet?)
+                    }
                 }
             }
         }
 
+        plot.wasIrrigated = false;
         return false;
     }
 

--- a/js/harvestManager.js
+++ b/js/harvestManager.js
@@ -72,6 +72,18 @@ class HarvestManager {
                  requiredSkill = "Investigation";
                  skillDifficulty = 5;
              }
+        } else if (tags.includes("harvest:corn")) {
+            lootTableId = "harvest:corn";
+            requiredSkill = "Survival";
+            skillDifficulty = 3;
+        } else if (tags.includes("harvest:carrot")) {
+            lootTableId = "harvest:carrot";
+            requiredSkill = "Survival";
+            skillDifficulty = 3;
+        } else if (tags.includes("harvest:tomato")) {
+            lootTableId = "harvest:tomato";
+            requiredSkill = "Survival";
+            skillDifficulty = 3;
         } else if (tags.includes("scavenge:junk")) {
             lootTableId = "scavenge:junk";
             requiredSkill = "Investigation";

--- a/js/interaction.js
+++ b/js/interaction.js
@@ -103,6 +103,7 @@ function _getActionsForItem(it) {
     if (tags.includes("harvest:sand")) actions.push("Harvest Sand");
     if (tags.includes("harvest:mud")) actions.push("Harvest Mud");
     if (tags.includes("harvest:gravel")) actions.push("Harvest Gravel");
+    if (tags.includes("harvest:corn") || tags.includes("harvest:carrot") || tags.includes("harvest:tomato")) actions.push("Harvest");
 
     // Scavenging
     if (tags.includes("scavenge:generic") || tags.includes("scavenge:junk")) actions.push("Scavenge");

--- a/js/inventoryManager.js
+++ b/js/inventoryManager.js
@@ -1517,24 +1517,15 @@ class InventoryManager {
         if (item.effects.hunger) {
             if (isPlayer) {
                 if (typeof this.gameState.playerHunger === 'undefined') this.gameState.playerHunger = maxNeeds;
+                // playerHunger acts as a satiety meter. Positive item.effects.hunger values increase satiety.
                 this.gameState.playerHunger = Math.min(this.gameState.playerHunger + item.effects.hunger, maxNeeds);
+                // Also clamp to 0 just in case
+                this.gameState.playerHunger = Math.max(0, this.gameState.playerHunger);
             } else {
                 if (typeof targetEntity.hunger === 'undefined') targetEntity.hunger = 0;
-                // NPC hunger: higher is hungrier? In player, hunger is satiety (max 24 is full)?
-                // Wait, logic says playerHunger + effect. Effect is positive?
-                // Let's check player logic: `applyHungerThirstDamage`: hunger--. If 0 -> starve.
-                // So hunger 24 = Full. hunger 0 = Starving.
-                // NPC logic `handleNpcOutOfCombatTurn`: npc.hunger += 1. Threshold 50.
-                // So NPC hunger is "Hunger Level" (0 = full, high = hungry).
-                // Player hunger is "Satiety" (24 = full, 0 = hungry).
-                // This is an inconsistency.
-                // Let's stick to player logic for now as this function serves player primarily,
-                // but we need to handle NPC correctly if they use it.
-                // If Item effect is positive (e.g. +5), it adds Satiety.
-                // For NPC, we should DECREASE hunger level.
                 if (targetEntity.hunger !== undefined) {
-                    targetEntity.hunger = Math.max(0, targetEntity.hunger - (item.effects.hunger * 10)); // Scale up? 1 food = ?
-                    // Let's just subtract raw value for now.
+                    // For NPC, higher hunger = hungrier. Positive effect means it restores satiety, so decrease NPC hunger.
+                    targetEntity.hunger = Math.max(0, targetEntity.hunger - (item.effects.hunger * 10));
                 }
             }
             consumed = true;

--- a/js/timeManager.js
+++ b/js/timeManager.js
@@ -73,7 +73,7 @@ const TimeManager = {
      * @param {object} gameState - The global game state.
      */
     processHourlyNeeds: function (gameState) {
-        // Hunger decrement (example: 1 point per hour)
+        // Hunger decrement (playerHunger acts as a satiety meter: 24 is full, 0 is starving)
         if (gameState.playerHunger > 0) {
             gameState.playerHunger--;
         } else {


### PR DESCRIPTION
Repairs the end-to-end farming and food consumption loop. Seeds can now be planted and grow through stages, irrigation continues on unloaded maps, ripe crops can be harvested for valid produce, and eating produce correctly improves satiety instead of causing starvation.

---
*PR created automatically by Jules for task [8448084036132469539](https://jules.google.com/task/8448084036132469539) started by @IndieBrosCEO*