### PR TITLE
Fix movement block order in movementUtils.js

### DIFF
--- a/js/movementUtils.js
+++ b/js/movementUtils.js
@@ -153,11 +153,6 @@ async function attemptCharacterMove(character, direction, assetManagerInstance, 
          window.mapRenderer.ensureLevelExists(originalPos.z - 1);
     }
 
-    if (targetX < 0 || targetX >= width || targetY < 0 || targetY >= height) {
-        logToConsole(`${logPrefix} Can't move that way (map boundary).`);
-        return false;
-    }
-
     // --- Determine Character's Current Tile Properties (moved before collision check) ---
     // CRITICAL FIX: This block must occur BEFORE the collision check below.
     // We need to know if the character is on a slope/z-transition to grant exceptions
@@ -185,6 +180,11 @@ async function attemptCharacterMove(character, direction, assetManagerInstance, 
             let charBaseIdBottom = (typeof charTileOnBottomRaw === 'object' && charTileOnBottomRaw?.tileId !== undefined) ? charTileOnBottomRaw.tileId : charTileOnBottomRaw;
             checkTileForZTransition(charBaseIdBottom);
         }
+    }
+
+    if (targetX < 0 || targetX >= width || targetY < 0 || targetY >= height) {
+        logToConsole(`${logPrefix} Can't move that way (map boundary).`);
+        return false;
     }
 
     // --- Multi-tile Rotation/Collision Check ---


### PR DESCRIPTION
Fix movement block order in movementUtils.js

Moved the block for determining a character's current tile properties (such as checking for z_transition tiles) to occur before the map boundary checks (`targetX < 0 || targetY < 0`, etc.). This ensures that necessary transition properties are parsed correctly for the character before any collision checks evaluate the target tile's validity, honoring the logic detailed in `js/movementUtils.js`.

---
*PR created automatically by Jules for task [5312198358968356850](https://jules.google.com/task/5312198358968356850) started by @IndieBrosCEO*